### PR TITLE
Added multi-platform input by keyboard

### DIFF
--- a/demos/input.go
+++ b/demos/input.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+	"goge/extras"
+)
+
+func main() {
+	fmt.Println("Press any key: ")
+
+	// This should work in any platform
+	keyPressed := extras.GetKeyPress()
+
+	switch keyPressed {
+	case 10:
+		fmt.Println("You pressed intro")
+		break
+	case 32:
+		fmt.Println("You pressed space bar")
+	default:
+		fmt.Println("You pressed a key with ASCII code ", keyPressed)
+	}
+}

--- a/extras/input.go
+++ b/extras/input.go
@@ -1,0 +1,41 @@
+package extras
+
+/*
+// Works also for 64 bits
+#ifdef _WIN32
+
+// Lib for console management in windows
+#include "conio.h"
+
+#else
+
+// Libs terminal management in Unix, Linux...
+#include <stdio.h>
+#include <unistd.h>
+#include <termios.h>
+
+// Implement reading a key pressed in terminal
+char getch(){
+    char ch = 0;
+    struct termios old = {0};
+    fflush(stdout);
+    if( tcgetattr(0, &old) < 0 ) perror("tcsetattr()");
+    old.c_lflag &= ~ICANON;
+    old.c_lflag &= ~ECHO;
+    old.c_cc[VMIN] = 1;
+    old.c_cc[VTIME] = 0;
+    if( tcsetattr(0, TCSANOW, &old) < 0 ) perror("tcsetattr ICANON");
+    if( read(0, &ch,1) < 0 ) perror("read()");
+    old.c_lflag |= ICANON;
+    old.c_lflag |= ECHO;
+    if(tcsetattr(0, TCSADRAIN, &old) < 0) perror("tcsetattr ~ICANON");
+    return ch;
+}
+#endif
+*/
+import "C"
+
+// GetKeyPress returns ASCII code of next pressed key
+func GetKeyPress() byte {
+	return byte(C.getch())
+}


### PR DESCRIPTION
Hi, with this solution you shouldn't need to init and stop the terminal like:

`exec.Command("stty",.....`

You just need to call GetKeyPress() wherever you need a key input. 
I tried myself the implementation in Linux Mint and Windows 7 and it works.